### PR TITLE
Fix version in `rdfizer` script POMs.

### DIFF
--- a/datasource-rdfizer/scripts/pom-rdf-gen-9606.xml
+++ b/datasource-rdfizer/scripts/pom-rdf-gen-9606.xml
@@ -1,25 +1,27 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.ucdenver.ccp</groupId>
 	<artifactId>datasource-rdfizer-rdf-gen</artifactId>
 	<packaging>pom</packaging>
-	<version>0.6-SNAPSHOT</version>
+    <version>0.6</version>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>edu.ucdenver.ccp</groupId>
-			<artifactId>datasource-rdfizer</artifactId>
-			<version>0.6-SNAPSHOT</version>
-			<type>jar</type>
-			<scope>compile</scope>
-		</dependency>
+      <dependency>
+        <groupId>edu.ucdenver.ccp</groupId>
+        <artifactId>datasource-rdfizer</artifactId>
+        <version>0.6</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
 	</dependencies>
-
 
 	<build>
 		<plugins>

--- a/datasource-rdfizer/scripts/pom-rdf-gen-ids.xml
+++ b/datasource-rdfizer/scripts/pom-rdf-gen-ids.xml
@@ -1,12 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.ucdenver.ccp</groupId>
   <artifactId>datasource-rdfizer-rdf-gen-ids</artifactId>
   <packaging>pom</packaging>
-  <version>0.6-SNAPSHOT</version>
+  <version>0.6</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -16,7 +17,7 @@
     <dependency>
       <groupId>edu.ucdenver.ccp</groupId>
       <artifactId>datasource-rdfizer</artifactId>
-      <version>0.6-SNAPSHOT</version>
+      <version>0.6</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/datasource-rdfizer/scripts/pom-rdf-gen-modelorgs.xml
+++ b/datasource-rdfizer/scripts/pom-rdf-gen-modelorgs.xml
@@ -1,25 +1,27 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.ucdenver.ccp</groupId>
 	<artifactId>datasource-rdfizer-rdf-gen</artifactId>
 	<packaging>pom</packaging>
-	<version>0.6-SNAPSHOT</version>
+    <version>0.6</version>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>edu.ucdenver.ccp</groupId>
-			<artifactId>datasource-rdfizer</artifactId>
-			<version>0.6-SNAPSHOT</version>
-			<type>jar</type>
-			<scope>compile</scope>
-		</dependency>
+      <dependency>
+        <groupId>edu.ucdenver.ccp</groupId>
+        <artifactId>datasource-rdfizer</artifactId>
+        <version>0.6</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
 	</dependencies>
-
 
 	<build>
 		<plugins>

--- a/datasource-rdfizer/scripts/pom-rdf-gen.xml
+++ b/datasource-rdfizer/scripts/pom-rdf-gen.xml
@@ -1,25 +1,27 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.ucdenver.ccp</groupId>
 	<artifactId>datasource-rdfizer-rdf-gen</artifactId>
 	<packaging>pom</packaging>
-	<version>0.6-SNAPSHOT</version>
+    <version>0.6</version>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>edu.ucdenver.ccp</groupId>
-			<artifactId>datasource-rdfizer</artifactId>
-			<version>0.6-SNAPSHOT</version>
-			<type>jar</type>
-			<scope>compile</scope>
-		</dependency>
+      <dependency>
+        <groupId>edu.ucdenver.ccp</groupId>
+        <artifactId>datasource-rdfizer</artifactId>
+        <version>0.6</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
 	</dependencies>
-
 
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.ucdenver.ccp</groupId>
 	<artifactId>datasource</artifactId>
@@ -6,10 +10,10 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- This property is inherited by all sub-modules and used to define their 
-			version -->
-		<project.version>0.6-SNAPSHOT</project.version>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <!-- This property is inherited by all sub-modules and used to define
+           their version -->
+      <project.version>0.6</project.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
With the main project at 0.6 proper, the script POMs should no longer
use the SNAPSHOT release of that version.