### PR TITLE
Handle unknown external ID in interpro2ipr files.

### DIFF
--- a/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/ebi/interpro/InterProExternalReferenceFactory.java
+++ b/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/ebi/interpro/InterProExternalReferenceFactory.java
@@ -34,6 +34,7 @@ package edu.ucdenver.ccp.datasource.fileparsers.ebi.interpro;
  */
 
 import edu.ucdenver.ccp.datasource.identifiers.DataSourceIdentifier;
+import edu.ucdenver.ccp.datasource.identifiers.UnknownDataSourceIdentifier;
 import edu.ucdenver.ccp.datasource.identifiers.ebi.interpro.Gene3dID;
 import edu.ucdenver.ccp.datasource.identifiers.ebi.interpro.HamapAnnotationRuleID;
 import edu.ucdenver.ccp.datasource.identifiers.ebi.interpro.PantherID;
@@ -63,7 +64,9 @@ public class InterProExternalReferenceFactory {
 	private static final String PRODOM_PREFIX = "PD";
 
 
-	public static DataSourceIdentifier<String> parseExternalReference(String databaseReferenceID) {
+    public static DataSourceIdentifier<String> parseExternalReference(
+			String databaseReferenceID)
+    {
 		if (databaseReferenceID.startsWith(PFAM_PREFIX))
 			return new PfamID(databaseReferenceID);
 		if (databaseReferenceID.startsWith(TIGRFAMS_PREFIX))
@@ -87,9 +90,9 @@ public class InterProExternalReferenceFactory {
 		if (databaseReferenceID.startsWith(HAMAP_PREFIX))
 			return new HamapAnnotationRuleID(databaseReferenceID);
 		if (databaseReferenceID.startsWith(PRODOM_PREFIX))
-			return new ProDomID(databaseReferenceID);
-		throw new IllegalArgumentException(String.format("Unknown external database ID type for ID: %s",
-				databaseReferenceID));
+            return new ProDomID(databaseReferenceID);
+
+        return new UnknownDataSourceIdentifier(databaseReferenceID);
 	}
 
 }

--- a/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/hgnc/HgncDownloadFileParser.java
+++ b/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/hgnc/HgncDownloadFileParser.java
@@ -558,7 +558,7 @@ public class HgncDownloadFileParser extends SingleLineFileRecordReader<HgncDownl
 			return new SlcId(idStr);
 		}
 
-		return new UnknownDataSourceIdentifier(idStr, null);
+		return new UnknownDataSourceIdentifier(idStr);
 	}
 
 	/**

--- a/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/irefweb/IRefWebPsiMitab2_6FileParser.java
+++ b/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/irefweb/IRefWebPsiMitab2_6FileParser.java
@@ -334,7 +334,7 @@ public class IRefWebPsiMitab2_6FileParser extends TaxonAwareSingleLineFileRecord
 				} else if (id.startsWith("HPRD")) {
 					ids.add(new HprdID(StringUtil.removePrefix(id, "HPRD:")));
 				} else {
-					ids.add(new UnknownDataSourceIdentifier(id, null));
+					ids.add(new UnknownDataSourceIdentifier(id));
 				}
 			} catch (IllegalArgumentException e) {
 				ids.add(new ProbableErrorDataSourceIdentifier(id, null, e.getMessage()));
@@ -360,10 +360,10 @@ public class IRefWebPsiMitab2_6FileParser extends TaxonAwareSingleLineFileRecord
 			return null;
 		}
 		if (idStr.startsWith("xx:")) {
-			return new UnknownDataSourceIdentifier(idStr, null);
+			return new UnknownDataSourceIdentifier(idStr);
 		}
 		if (idStr.startsWith("other:")) {
-			return new UnknownDataSourceIdentifier(idStr, null);
+			return new UnknownDataSourceIdentifier(idStr);
 		}
 		if (idStr.equals("null")) {
 			return null;
@@ -486,7 +486,7 @@ public class IRefWebPsiMitab2_6FileParser extends TaxonAwareSingleLineFileRecord
 			return new ProbableErrorDataSourceIdentifier(idStr, null, e.getMessage());
 		}
 
-		return new UnknownDataSourceIdentifier(idStr, null);
+		return new UnknownDataSourceIdentifier(idStr);
 	}
 
 	/**
@@ -683,7 +683,7 @@ public class IRefWebPsiMitab2_6FileParser extends TaxonAwareSingleLineFileRecord
 		} else if (aliasStr.startsWith("hgnc:")) {
 			return new HgncGeneSymbolID(StringUtil.removePrefix(aliasStr, "hgnc:"));
 		}
-		return new UnknownDataSourceIdentifier(aliasStr, null);
+		return new UnknownDataSourceIdentifier(aliasStr);
 	}
 
 }

--- a/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/pharmgkb/PharmGkbGeneFileParser.java
+++ b/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/pharmgkb/PharmGkbGeneFileParser.java
@@ -274,7 +274,7 @@ public class PharmGkbGeneFileParser extends SingleLineFileRecordReader<PharmGkbG
 			} else if (refStr.startsWith(URL_PREFIX)) {
 				return new CrossReferenceUrl(StringUtil.removePrefix(refStr, URL_PREFIX));
 			} else {
-				return new UnknownDataSourceIdentifier(refStr, null);
+				return new UnknownDataSourceIdentifier(refStr);
 			}
 		} catch (IllegalArgumentException e) {
 			return new ProbableErrorDataSourceIdentifier(refStr, null, e.getMessage());

--- a/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/pharmgkb/PharmGkbRelationFileParser.java
+++ b/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/pharmgkb/PharmGkbRelationFileParser.java
@@ -2,9 +2,10 @@ package edu.ucdenver.ccp.datasource.fileparsers.pharmgkb;
 
 /*
  * #%L
- * Colorado Computational Pharmacology's common module
+ * Colorado Computational Pharmacology's datasource
+ * 							project
  * %%
- * Copyright (C) 2012 - 2015 Regents of the University of Colorado
+ * Copyright (C) 2012 - 2016 Regents of the University of Colorado
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -33,6 +34,37 @@ package edu.ucdenver.ccp.datasource.fileparsers.pharmgkb;
  * #L%
  */
 
+/*
+ * Colorado Computational Pharmacology's common module
+ *
+ * Copyright (C) 2012 - 2015 Regents of the University of Colorado
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Regents of the University of Colorado nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 import java.io.File;
 import java.io.IOException;
@@ -128,7 +160,7 @@ public class PharmGkbRelationFileParser extends SingleLineFileRecordReader<Pharm
 			} else if (entityType.equals(ENTITY_TYPE_VARIANT_LOCATION)) {
 				ids.add(new PharmGkbVariantLocationId(id));
 			} else {
-				ids.add(new UnknownDataSourceIdentifier(id, null));
+				ids.add(new UnknownDataSourceIdentifier(id));
 			}
 		}
 		return ids;

--- a/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/pro/ProMappingFileParser.java
+++ b/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/pro/ProMappingFileParser.java
@@ -139,6 +139,6 @@ public class ProMappingFileParser extends SingleLineFileRecordReader<ProMappingR
 		} catch (IllegalArgumentException e) {
 			return new ProbableErrorDataSourceIdentifier(idStr, null, e.getMessage());
 		}
-		return new UnknownDataSourceIdentifier(idStr, null);
+		return new UnknownDataSourceIdentifier(idStr);
 	}
 }

--- a/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/rgd/RgdAnnotationFileIdResolver.java
+++ b/datasource-fileparsers/src/main/java/edu/ucdenver/ccp/datasource/fileparsers/rgd/RgdAnnotationFileIdResolver.java
@@ -117,7 +117,7 @@ public class RgdAnnotationFileIdResolver implements IdResolver {
 		if (idStr.startsWith("UniProtKB:")) {
 			return new UniProtID(idStr.substring(10));
 		}
-		return new UnknownDataSourceIdentifier(idStr, null);
+		return new UnknownDataSourceIdentifier(idStr);
 	}
 
 	/*

--- a/datasource-fileparsers/src/test/java/edu/ucdenver/ccp/datasource/fileparsers/interpro/InterProProtein2IprDatFileParserTest.java
+++ b/datasource-fileparsers/src/test/java/edu/ucdenver/ccp/datasource/fileparsers/interpro/InterProProtein2IprDatFileParserTest.java
@@ -1,0 +1,133 @@
+
+/*
+ * Colorado Computational Pharmacology's datasource module
+ *
+ * Copyright (C) 2012 - 2016 Regents of the University of Colorado
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Regents of the University of Colorado nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package edu.ucdenver.ccp.datasource.fileparsers.interpro;
+
+/*
+ * #%L
+ * Colorado Computational Pharmacology's datasource
+ * 							project
+ * %%
+ * Copyright (C) 2012 - 2016 Regents of the University of Colorado
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Regents of the University of Colorado nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import edu.ucdenver.ccp.common.file.CharacterEncoding;
+import edu.ucdenver.ccp.common.file.reader.Line;
+import edu.ucdenver.ccp.datasource.fileparsers.ebi.interpro.InterProProtein2IprDatFileData;
+import edu.ucdenver.ccp.datasource.fileparsers.ebi.interpro.InterProProtein2IprDatFileParser;
+import edu.ucdenver.ccp.datasource.identifiers.UnknownDataSourceIdentifier;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class InterProProtein2IprDatFileParserTest {
+
+    @Test
+    public void parseLineWithUnknownExternalId()
+        throws Exception
+    {
+        InterProProtein2IprDatFileData dat =
+            new TestParser().parseRecordFromLine(
+                makeLine(
+                    "A0A004\tIPR001962\tAsparagine synthase\tcd01991\t241\t565"));
+        // Doesn't throw an error for unknown IDs.
+        assertNotNull(dat);
+        // External ID handled correctly.
+        assertThat(dat.getExternalReference(),
+                   instanceOf(UnknownDataSourceIdentifier.class));
+    }
+
+    /* --------------------------------------------------------------------- */
+
+    static class TestParser extends InterProProtein2IprDatFileParser
+    {
+        TestParser()
+            throws IOException
+        {
+            super(makeTempFile(), CharacterEncoding.US_ASCII);
+        }
+
+        private static File makeTempFile()
+            throws IOException
+        {
+            File f = File.createTempFile("protein2ipr", null);
+            f.deleteOnExit();
+            return f;
+        }
+
+        public InterProProtein2IprDatFileData parseRecordFromLine(Line l) {
+            return super.parseRecordFromLine(l);
+        }
+    }
+
+    private Line makeLine(String textSansTerminator) {
+        return new Line(textSansTerminator,
+                        Line.LineTerminator.CR,
+                        0,  // character offset
+                        0,  // code point offset
+                        1,  // line number
+                        -1); // byte offset
+    }
+}

--- a/datasource-fileparsers/src/test/java/edu/ucdenver/ccp/datasource/fileparsers/pro/ProMappingFileParserTest.java
+++ b/datasource-fileparsers/src/test/java/edu/ucdenver/ccp/datasource/fileparsers/pro/ProMappingFileParserTest.java
@@ -109,16 +109,24 @@ public class ProMappingFileParserTest extends RecordReaderTester {
 	}
 
 	private void validateRecord1(ProMappingRecord record) {
-		validateRecord(record, new ProteinOntologyId("PR:000000005"), "is_a", new HgncID("HGNC:11773"));
+        validateRecord(record,
+                       new ProteinOntologyId("PR:000000005"),
+                       "is_a",
+                       new HgncID("HGNC:11773"));
 	}
 
 	private void validateRecord2(ProMappingRecord record) {
-		validateRecord(record, new ProteinOntologyId("PR:000000005"), "is_a", new UnknownDataSourceIdentifier(
-				"UniProtKB_VAR:VAR_022359", null));
+        validateRecord(record,
+                       new ProteinOntologyId("PR:000000005"),
+                       "is_a",
+                       new UnknownDataSourceIdentifier("UniProtKB_VAR:VAR_022359"));
 	}
 
 	private void validateRecord3(ProMappingRecord record) {
-		validateRecord(record, new ProteinOntologyId("PR:000000006"), "exact", new UniProtID("P37173"));
+        validateRecord(record,
+                       new ProteinOntologyId("PR:000000006"),
+                       "exact",
+                       new UniProtID("P37173"));
 	}
 
 }

--- a/datasource-identifiers/src/main/java/edu/ucdenver/ccp/datasource/identifiers/DataSourceIdResolver.java
+++ b/datasource-identifiers/src/main/java/edu/ucdenver/ccp/datasource/identifiers/DataSourceIdResolver.java
@@ -452,7 +452,7 @@ public class DataSourceIdResolver {
 				return new NcbiTaxonomyID(StringUtil.removePrefix(geneIDStr, "NCBITaxon:"));
 
 			logger.warn(String.format("Unhandled gene ID format: %s. Creating UnknownDataSourceIdentifier.", geneIDStr));
-			return new UnknownDataSourceIdentifier(geneIDStr, null);
+			return new UnknownDataSourceIdentifier(geneIDStr);
 		} catch (IllegalArgumentException e) {
 			logger.warn("Invalid ID detected... " + e.getMessage());
 			return new ProbableErrorDataSourceIdentifier(geneIDStr, null, e.getMessage());
@@ -481,7 +481,7 @@ public class DataSourceIdResolver {
 
 		logger.warn(String.format("Unknown interaction ID format: %s. Cannot create DataElementIdentifier<?>.",
 				interactionIDStr));
-		return new UnknownDataSourceIdentifier(interactionIDStr, null);
+		return new UnknownDataSourceIdentifier(interactionIDStr);
 	}
 
 	/**

--- a/datasource-identifiers/src/main/java/edu/ucdenver/ccp/datasource/identifiers/UnknownDataSourceIdentifier.java
+++ b/datasource-identifiers/src/main/java/edu/ucdenver/ccp/datasource/identifiers/UnknownDataSourceIdentifier.java
@@ -34,6 +34,38 @@ package edu.ucdenver.ccp.datasource.identifiers;
  * #L%
  */
 
+/*
+ * Colorado Computational Pharmacology's datasource project
+ *
+ * Copyright (C) 2012 - 2016 Regents of the University of Colorado
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Regents of the University of Colorado nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 public class UnknownDataSourceIdentifier extends DataSourceIdentifier<String> {
 
 	private final String dataSourceStr;
@@ -41,6 +73,17 @@ public class UnknownDataSourceIdentifier extends DataSourceIdentifier<String> {
 	public UnknownDataSourceIdentifier(String resourceID,  String dataSourceStr) {
 		super(resourceID, DataSource.UNKNOWN);
 		this.dataSourceStr = dataSourceStr;
+	}
+
+    /**
+     * Constructor that may be used when a canonical identifier for the source
+     * in which the resource identifier is defined is not available.
+     *
+     * @param resourceID
+     *   The identifier for the resource in the external, unknown source.
+     */
+	public UnknownDataSourceIdentifier(String resourceID) {
+		this(resourceID, null);
 	}
 
 	@Override


### PR DESCRIPTION
Since we're not in control of the external datasources that are used by
datasource providers, validating all external IDs makes our code
brittle.  Since we don't use sources that we don't know about, we can
simply gloss over the external IDs that we don't recognise.

Doing so yields triples of the form:

```
<http://kabob.ucdenver.edu/iao/interpro/F_InterProProtein2IprDatFileData_externalReference_J7eGDFPyhBVMdgpi5AN9XzD1tu8> <http://purl.obolibrary.org/obo/IAO_0000219> <http://kabob.ucdenver.edu/iao/kabob/R_NonNormalizedIdentifierRecord_fM4tG2mEQK7AzC4Z0DKJDbkbNGU> .
<http://kabob.ucdenver.edu/iao/kabob/R_NonNormalizedIdentifierRecord_fM4tG2mEQK7AzC4Z0DKJDbkbNGU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://kabob.ucdenver.edu/iao/kabob/NonNormalizedIdentifierRecord> .
<http://kabob.ucdenver.edu/iao/kabob/R_NonNormalizedIdentifierRecord_fM4tG2mEQK7AzC4Z0DKJDbkbNGU> <http://kabob.ucdenver.edu/iao/hasTemplate> <http://kabob.ucdenver.edu/iao/kabob/NonNormalizedIdentifierRecordSchema1> .
<http://kabob.ucdenver.edu/iao/kabob/R_NonNormalizedIdentifierRecord_fM4tG2mEQK7AzC4Z0DKJDbkbNGU> <http://purl.obolibrary.org/obo/BFO_0000051> <http://kabob.ucdenver.edu/iao/kabob/F_NonNormalizedIdentifierRecord_identifier_fM4tG2mEQK7AzC4Z0DKJDbkbNGU> .
<http://kabob.ucdenver.edu/iao/kabob/F_NonNormalizedIdentifierRecord_identifier_fM4tG2mEQK7AzC4Z0DKJDbkbNGU> <http://kabob.ucdenver.edu/iao/hasTemplate> <http://kabob.ucdenver.edu/iao/kabob/NonNormalizedIdentifierRecord_identifierDataField1> .
<http://kabob.ucdenver.edu/iao/kabob/F_NonNormalizedIdentifierRecord_identifier_fM4tG2mEQK7AzC4Z0DKJDbkbNGU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://kabob.ucdenver.edu/iao/FieldValue> .
<http://kabob.ucdenver.edu/iao/kabob/F_NonNormalizedIdentifierRecord_identifier_fM4tG2mEQK7AzC4Z0DKJDbkbNGU> <http://purl.obolibrary.org/obo/IAO_0000219> "cd01991"@en .
```